### PR TITLE
moved browserify and watchify deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,19 +39,19 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "browserify": "^13.0.0",
     "glob": "^6.0.3",
     "lodash": "^3.10.1",
-    "resolve": "^1.1.6",
-    "watchify": "^3.6.1"
+    "resolve": "^1.1.6"
   },
   "devDependencies": {
+    "browserify": "^13.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-jshint": "^0.11.3",
     "mocha": "^2.3.4",
-    "sinon": "^1.17.2"
+    "sinon": "^1.17.2",
+    "watchify": "^3.6.1"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
fix memory leaks warnings in my setup : sails & browserify installed globally.
When browserify is installed globally AND locally, this ends up with :

error: Grunt :: (node) warning: possible EventEmitter memory leak detected. 11 change listeners added. Use emitter.setMaxListeners() to increase limit.
